### PR TITLE
Mix task to view owners for project files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @reid-rigo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,27 @@
 # Changelog
 
-# 0.1.6
+## Unreleased
+
+Mix task to view owners for project files
+
+## 0.1.6
 
 Allow specifying root when calling load or build as alternative to `File.cwd!`
 
-# 0.1.5
+## 0.1.5
 
 Handle inline comments
 
-# 0.1.4
+## 0.1.4
 
 - `root` must be present, so use `File.cwd!`
 - Fix . handling in patterns
 
-# 0.1.3
+## 0.1.3
 
 Complete typespecs
 
-# 0.1.2
+## 0.1.2
 
 Custom inspect to make output more sane
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codeowners
 
-A pure Elixir parser for the Github CODEOWNERS [specification](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
+A pure Elixir parser for the GitHub CODEOWNERS [specification](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ end
 }
 ```
 
+## Mix task
+
+```sh
+~/my_project/:$ mix codeowners README.md
+Using .github/CODEOWNERS
+README.md    @my-team
+```
+
 ## License
 
 MIT License - see the [LICENSE](https://github.com/reid-rigo/codeowners/blob/main/LICENSE) file.

--- a/lib/codeowners.ex
+++ b/lib/codeowners.ex
@@ -1,6 +1,6 @@
 defmodule Codeowners do
   @moduledoc """
-  A pure Elixir parser for the Github CODEOWNERS [specification](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
+  A pure Elixir parser for the GitHub CODEOWNERS [specification](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
 
   ```elixir
   > Codeowners.load(".github/CODEOWNERS") |> Codeowners.rule_for_path("docs/setup.md")

--- a/lib/mix/tasks/codeowners.ex
+++ b/lib/mix/tasks/codeowners.ex
@@ -1,10 +1,26 @@
 defmodule Mix.Tasks.Codeowners do
-  @moduledoc ""
-  @shortdoc "TODO"
+  @moduledoc """
+  List owners for files based on CODEOWNERS.
+
+      mix codeowners lib/
+  """
+  @shortdoc "List owners for files based on CODEOWNERS"
 
   use Mix.Task
 
   @impl Mix.Task
+  def run([]) do
+    warning = IO.ANSI.format([:red, "No files or directories provided\n"])
+    IO.puts(warning)
+
+    usage = [
+      "Example:\n\t",
+      IO.ANSI.format([:bright, "mix codeowners lib/"])
+    ]
+
+    IO.puts(Enum.join(usage))
+  end
+
   def run(args) do
     codeowners = Codeowners.load(codeowners_path())
     IO.puts(IO.ANSI.format([:green, "Using " <> codeowners.path]))
@@ -42,20 +58,13 @@ defmodule Mix.Tasks.Codeowners do
     end)
   end
 
+  defp relative_paths_from_args(["."]), do: relative_paths_from_args(["*"])
+
   # convert args to a list of relative paths to be checked
   defp relative_paths_from_args(args) do
-    args =
-      case args do
-        [] -> ["**"]
-        ["."] -> ["**"]
-        _ -> args
-      end
-
     Enum.flat_map(args, fn arg ->
-      pattern = if File.dir?(arg), do: arg <> "/**", else: arg
-      Path.wildcard(pattern)
+      Path.wildcard(arg)
     end)
-    |> Enum.reject(&File.dir?/1)
     |> Enum.sort()
   end
 

--- a/lib/mix/tasks/codeowners.ex
+++ b/lib/mix/tasks/codeowners.ex
@@ -1,0 +1,69 @@
+defmodule Mix.Tasks.Codeowners do
+  @moduledoc ""
+  @shortdoc "TODO"
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(args) do
+    codeowners = Codeowners.load(codeowners_path())
+    IO.puts(IO.ANSI.format([:green, "Using " <> codeowners.path]))
+
+    summary =
+      relative_paths_from_args(args)
+      |> Enum.map(fn path ->
+        [path, Codeowners.rule_for_path(codeowners, "/" <> path).owners]
+      end)
+      |> output_lines()
+      |> Enum.join("\r\n")
+
+    IO.puts(summary)
+  end
+
+  # convert list of pairs to strings for output
+  defp output_lines(results) do
+    width =
+      results
+      |> Enum.map(fn [path, _] -> String.length(path) end)
+      |> Enum.max(&>/2, fn -> 0 end)
+      |> then(fn n -> n + 4 end)
+
+    Enum.map(results, fn [path, owners] ->
+      padded_path = String.pad_trailing(path, width)
+
+      owners_string =
+        case owners do
+          [] -> IO.ANSI.format([:faint, "No one"])
+          _ -> IO.ANSI.format([:blue, Enum.join(owners, " ")])
+        end
+        |> IO.chardata_to_string()
+
+      padded_path <> owners_string
+    end)
+  end
+
+  # convert args to a list of relative paths to be checked
+  defp relative_paths_from_args(args) do
+    args =
+      case args do
+        [] -> ["**"]
+        ["."] -> ["**"]
+        _ -> args
+      end
+
+    Enum.flat_map(args, fn arg ->
+      pattern = if File.dir?(arg), do: arg <> "/**", else: arg
+      Path.wildcard(pattern)
+    end)
+    |> Enum.reject(&File.dir?/1)
+    |> Enum.sort()
+  end
+
+  # for convenience, find CODEOWNERS following GitHub's allowed locations
+  defp codeowners_path() do
+    Enum.find(
+      ~w(.github/CODEOWNERS CODEOWNERS docs/CODEOWNERS),
+      &File.exists?/1
+    )
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule Codeowners.MixProject do
 
   defp description do
     """
-    A pure Elixir parser for the Github CODEOWNERS specification.
+    A pure Elixir parser for the GitHub CODEOWNERS specification.
     """
   end
 

--- a/test/mix/tasks/codeowners_test.exs
+++ b/test/mix/tasks/codeowners_test.exs
@@ -1,0 +1,49 @@
+defmodule Mix.Tasks.CodeownersTest do
+  @moduledoc false
+
+  use ExUnit.Case
+
+  describe "run" do
+    test "prints detected CODEOWNERS" do
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          Mix.Tasks.Codeowners.run(["README.md"])
+        end)
+
+      assert String.contains?(output, "Using .github/CODEOWNERS")
+    end
+
+    test "prints owners" do
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          Mix.Tasks.Codeowners.run(["README.md"])
+        end)
+
+      last_line =
+        output
+        |> String.split("\n", trim: true)
+        |> List.last()
+
+      assert String.contains?(last_line, "README.md")
+    end
+
+    test "prints a warning message" do
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          Mix.Tasks.Codeowners.run([])
+        end)
+
+      assert String.contains?(output, "No files or directories provided")
+    end
+
+    test "prints a usage message" do
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          Mix.Tasks.Codeowners.run([])
+        end)
+
+      assert String.contains?(output, "Example:")
+      assert String.contains?(output, "mix codeowners lib/")
+    end
+  end
+end


### PR DESCRIPTION
```sh
~/my_project/:$ mix codeowners README.md
Using .github/CODEOWNERS
README.md    @my-team
```